### PR TITLE
feat: [PROPOSAL] Defining new API for recover single payments

### DIFF
--- a/src/main/java/it/gov/pagopa/bizevents/sync/nodo/config/datasource/HistoricDataSourceConfig.java
+++ b/src/main/java/it/gov/pagopa/bizevents/sync/nodo/config/datasource/HistoricDataSourceConfig.java
@@ -1,0 +1,61 @@
+package it.gov.pagopa.bizevents.sync.nodo.config.datasource;
+
+import com.zaxxer.hikari.HikariDataSource;
+import jakarta.persistence.EntityManagerFactory;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+@Configuration
+@EnableTransactionManagement
+@EnableJpaRepositories(
+    basePackages = "it.gov.pagopa.bizevents.sync.nodo.repository.historic",
+    entityManagerFactoryRef = "historicEntityManagerFactory",
+    transactionManagerRef = "historicTransactionManager")
+public class HistoricDataSourceConfig {
+
+  @Bean(name = "historicDataSource")
+  /*
+  @ConfigurationProperties(prefix = "historic.datasource")
+  public HikariDataSource dataSource() {
+      return new HikariDataSource();
+  }*/
+  public DataSource dataSource(
+      @Value("${historic.datasource.url}") String url,
+      @Value("${historic.datasource.username}") String username,
+      @Value("${historic.datasource.password}") String password,
+      @Value("${historic.datasource.driver-class-name}") String driverClassName) {
+    HikariDataSource ds = new HikariDataSource();
+    ds.setJdbcUrl(url);
+    ds.setUsername(username);
+    ds.setPassword(password);
+    ds.setDriverClassName(driverClassName);
+    return ds;
+  }
+
+  @Bean(name = "historicEntityManagerFactory")
+  public LocalContainerEntityManagerFactoryBean entityManagerFactory(
+      EntityManagerFactoryBuilder builder, @Qualifier("historicDataSource") DataSource dataSource) {
+    return builder
+        .dataSource(dataSource)
+        .packages(
+            "it.gov.pagopa.bizevents.sync.nodo.entity.nodo.oldmodel",
+            "it.gov.pagopa.bizevents.sync.nodo.entity.nodo.newmodel")
+        .persistenceUnit("historic")
+        .build();
+  }
+
+  @Bean(name = "historicTransactionManager")
+  public PlatformTransactionManager transactionManager(
+      @Qualifier("historicEntityManagerFactory") EntityManagerFactory emf) {
+    return new JpaTransactionManager(emf);
+  }
+}

--- a/src/main/java/it/gov/pagopa/bizevents/sync/nodo/config/datasource/PrimaryDataSourceConfig.java
+++ b/src/main/java/it/gov/pagopa/bizevents/sync/nodo/config/datasource/PrimaryDataSourceConfig.java
@@ -1,0 +1,67 @@
+package it.gov.pagopa.bizevents.sync.nodo.config.datasource;
+
+import com.zaxxer.hikari.HikariDataSource;
+import jakarta.persistence.EntityManagerFactory;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+@Configuration
+@EnableTransactionManagement
+@EnableJpaRepositories(
+    basePackages = {
+      "it.gov.pagopa.bizevents.sync.nodo.repository.primary.payment",
+      "it.gov.pagopa.bizevents.sync.nodo.repository.primary.receipt"
+    },
+    entityManagerFactoryRef = "primaryEntityManagerFactory",
+    transactionManagerRef = "primaryTransactionManager")
+public class PrimaryDataSourceConfig {
+
+  @Bean(name = "primaryDataSource")
+  @Primary
+  // @ConfigurationProperties("spring.datasource")
+  /*public HikariDataSource dataSource() {
+      return new HikariDataSource();
+  }*/
+  public DataSource dataSource(
+      @Value("${spring.datasource.url}") String url,
+      @Value("${spring.datasource.username}") String username,
+      @Value("${spring.datasource.password}") String password,
+      @Value("${spring.datasource.driver-class-name}") String driverClassName) {
+    HikariDataSource ds = new HikariDataSource();
+    ds.setJdbcUrl(url);
+    ds.setUsername(username);
+    ds.setPassword(password);
+    ds.setDriverClassName(driverClassName);
+    return ds;
+  }
+
+  @Bean(name = "primaryEntityManagerFactory")
+  @Primary
+  public LocalContainerEntityManagerFactoryBean entityManagerFactory(
+      EntityManagerFactoryBuilder builder, @Qualifier("primaryDataSource") DataSource dataSource) {
+    return builder
+        .dataSource(dataSource)
+        .packages(
+            "it.gov.pagopa.bizevents.sync.nodo.entity.nodo.oldmodel",
+            "it.gov.pagopa.bizevents.sync.nodo.entity.nodo.newmodel")
+        .persistenceUnit("primary")
+        .build();
+  }
+
+  @Bean(name = "primaryTransactionManager")
+  @Primary
+  public PlatformTransactionManager transactionManager(
+      @Qualifier("primaryEntityManagerFactory") EntityManagerFactory emf) {
+    return new JpaTransactionManager(emf);
+  }
+}

--- a/src/main/java/it/gov/pagopa/bizevents/sync/nodo/controller/SyncController.java
+++ b/src/main/java/it/gov/pagopa/bizevents/sync/nodo/controller/SyncController.java
@@ -11,11 +11,7 @@ import java.util.Calendar;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController()
 @Slf4j
@@ -61,6 +57,39 @@ public class SyncController {
             dateFrom, dateTo, overriddenTimeSlotSize, showBizEvents);
     log.info(
         "Invoked BizEvent-to-Nodo synchronization via HTTP manual trigger completed in [{}] ms!",
+        CommonUtility.getTimelapse(start));
+    return ResponseEntity.status(HttpStatus.OK).body(report);
+  }
+
+  @Operation(
+      summary = "Manually synchronize single BizEvents",
+      description = "Execute a synchronization for single event, manually starting the operation",
+      tags = {"Manual"})
+  @GetMapping(value = "/synchronize/single")
+  @ResponseStatus(HttpStatus.OK)
+  public ResponseEntity<SyncReport> manuallySynchronizeSingleEvent(
+      @NotNull
+          @RequestParam(name = "dateFrom")
+          @Schema(example = "2025-01-01T12:00:00", description = "Lower limit date")
+          LocalDateTime dateFrom,
+      @NotNull
+          @RequestParam(name = "dateTo")
+          @Schema(example = "2025-01-01T21:00:00", description = "Upper limit date")
+          LocalDateTime dateTo,
+      @RequestParam(name = "domainId")
+          @Schema(example = "77777777777", description = "Creditor institution identifier")
+          String domainId,
+      @RequestParam(name = "noticeNumber")
+          @Schema(example = "300000000000000000", description = "Notice number")
+          String noticeNumber) {
+
+    log.info("Invoking BizEvent-to-Nodo single BizEvent synchronization!");
+    long start = Calendar.getInstance().getTimeInMillis();
+    SyncReport report =
+        bizEventSynchronizerService.executeSynchronizationForSingleReceipt(
+            dateFrom, dateTo, domainId, noticeNumber);
+    log.info(
+        "Invoked BizEvent-to-Nodo single BizEvent synchronization completed in [{}] ms!",
         CommonUtility.getTimelapse(start));
     return ResponseEntity.status(HttpStatus.OK).body(report);
   }

--- a/src/main/java/it/gov/pagopa/bizevents/sync/nodo/entity/nodo/newmodel/PositionTransfer.java
+++ b/src/main/java/it/gov/pagopa/bizevents/sync/nodo/entity/nodo/newmodel/PositionTransfer.java
@@ -1,11 +1,6 @@
 package it.gov.pagopa.bizevents.sync.nodo.entity.nodo.newmodel;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.Id;
-import jakarta.persistence.OneToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.Setter;
@@ -67,9 +62,6 @@ public class PositionTransfer {
 
   @Column(name = "REQ_PROVINCIA_RESIDENZA", length = 2)
   private String reqProvinciaResidenza;
-
-  @Column(name = "COMPANY_NAME_SECONDARY")
-  private String companyNameSecondary;
 
   @Column(name = "INSERTED_BY")
   private String insertedBy;

--- a/src/main/java/it/gov/pagopa/bizevents/sync/nodo/entity/nodo/oldmodel/Rpt.java
+++ b/src/main/java/it/gov/pagopa/bizevents/sync/nodo/entity/nodo/oldmodel/Rpt.java
@@ -16,7 +16,7 @@ public class Rpt {
 
   @Id
   @Column(name = "ID")
-  private long id;
+  private Long id;
 
   @Column(name = "ID_SESSIONE")
   private String idSessione;
@@ -64,19 +64,19 @@ public class Rpt {
   private String tipoVersamento;
 
   @Column(name = "NUM_VERSAMENTI")
-  private long numVersamenti;
+  private Long numVersamenti;
 
   @Column(name = "RT_SIGNATURE_CODE")
-  private long rtSignatureCode;
+  private Long rtSignatureCode;
 
   @Column(name = "SOMMA_VERSAMENTI")
-  private long sommaVersamenti;
+  private Long sommaVersamenti;
 
   @Column(name = "PARAMETRI_PROFILO_PAGAMENTO")
   private String parametriProfiloPagamento;
 
   @Column(name = "FK_CARRELLO")
-  private long fkCarrello;
+  private Long fkCarrello;
 
   @Column(name = "INSERTED_TIMESTAMP")
   private LocalDateTime insertedTimestamp;

--- a/src/main/java/it/gov/pagopa/bizevents/sync/nodo/entity/nodo/oldmodel/Rt.java
+++ b/src/main/java/it/gov/pagopa/bizevents/sync/nodo/entity/nodo/oldmodel/Rt.java
@@ -13,7 +13,7 @@ public class Rt {
 
   @Id
   @Column(name = "ID")
-  private long id;
+  private Long id;
 
   @Column(name = "ID_SESSIONE")
   private String idSessione;
@@ -28,7 +28,7 @@ public class Rt {
   private String iuv;
 
   @Column(name = "COD_ESITO")
-  private int codEsito;
+  private Integer codEsito;
 
   @Column(name = "ESITO")
   private String esito;
@@ -46,7 +46,7 @@ public class Rt {
   private String idRichiesta;
 
   @Column(name = "SOMMA_VERSAMENTI")
-  private long sommaVersamenti;
+  private Long sommaVersamenti;
 
   @Column(name = "INSERTED_TIMESTAMP")
   private LocalDateTime insertedTimestamp;

--- a/src/main/java/it/gov/pagopa/bizevents/sync/nodo/repository/BizEventsRepository.java
+++ b/src/main/java/it/gov/pagopa/bizevents/sync/nodo/repository/BizEventsRepository.java
@@ -30,6 +30,27 @@ public interface BizEventsRepository extends CosmosRepository<BizEvent, String> 
 
   @Query(
       """
+      SELECT
+        c.debtorPosition.noticeNumber != null ?
+          c.debtorPosition.noticeNumber :
+          c.debtorPosition.iuv as iuv,
+        c.paymentInfo.paymentToken as paymentToken,
+        c.creditor.idPA as domainId,
+        StringToNumber(c.debtorPosition.modelType) = 1 ? "OLD" : "NEW" as version
+      FROM c
+      WHERE c.paymentInfo.paymentDateTime >= @minDate
+        AND c.paymentInfo.paymentDateTime < @maxDate
+        AND c.creditor.idPA = @domainId
+        AND c.debtorPosition.noticeNumber = @noticeNumber
+      """)
+  Set<Map<String, Object>> readBizEventsByDomainAndNoticeNumber(
+      @Param("minDate") String minDate,
+      @Param("maxDate") String maxDate,
+      @Param("domainId") String domainId,
+      @Param("noticeNumber") String noticeNumber);
+
+  @Query(
+      """
       SELECT VALUE COUNT(e)
       FROM e
       WHERE e.paymentInfo.paymentDateTime >= @minDate

--- a/src/main/java/it/gov/pagopa/bizevents/sync/nodo/repository/historic/payment/HistoricPaymentPositionRepository.java
+++ b/src/main/java/it/gov/pagopa/bizevents/sync/nodo/repository/historic/payment/HistoricPaymentPositionRepository.java
@@ -1,0 +1,32 @@
+package it.gov.pagopa.bizevents.sync.nodo.repository.historic.payment;
+
+import it.gov.pagopa.bizevents.sync.nodo.entity.nodo.newmodel.PositionPayment;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface HistoricPaymentPositionRepository extends JpaRepository<PositionPayment, Long> {
+
+  @Query(
+      """
+      SELECT pp
+      FROM PositionPayment pp
+      WHERE pp.insertedTimestamp >= :minDate
+        AND pp.insertedTimestamp < :maxDate
+        AND pp.paymentToken = :paymentToken
+      """)
+  Optional<PositionPayment> readByPaymentTokenInTimeSlot(
+      @Param("minDate") LocalDateTime minDate,
+      @Param("maxDate") LocalDateTime maxDate,
+      @Param("paymentToken") String paymentToken);
+
+  @Query(
+      """
+      SELECT COUNT(pp)
+      FROM PositionPayment pp
+      WHERE pp.transactionId = :transactionId
+      """)
+  Long countPositionPaymentsByTransactionId(@Param("transactionId") String transactionId);
+}

--- a/src/main/java/it/gov/pagopa/bizevents/sync/nodo/repository/historic/payment/HistoricPositionTransferRepository.java
+++ b/src/main/java/it/gov/pagopa/bizevents/sync/nodo/repository/historic/payment/HistoricPositionTransferRepository.java
@@ -1,0 +1,22 @@
+package it.gov.pagopa.bizevents.sync.nodo.repository.historic.payment;
+
+import it.gov.pagopa.bizevents.sync.nodo.entity.nodo.newmodel.PositionTransfer;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface HistoricPositionTransferRepository extends JpaRepository<PositionTransfer, Long> {
+
+  @Query(
+      """
+      SELECT pt
+      FROM PositionTransfer pt
+      WHERE pt.fkPositionPayment = :positionPaymentId
+        AND pt.insertedTimestamp >= :minDate
+      ORDER BY pt.transferIdentifier ASC
+      """)
+  List<PositionTransfer> readByPositionPayment(
+      @Param("positionPaymentId") Long positionPaymentId, @Param("minDate") LocalDateTime minDate);
+}

--- a/src/main/java/it/gov/pagopa/bizevents/sync/nodo/repository/historic/payment/HistoricRptRepository.java
+++ b/src/main/java/it/gov/pagopa/bizevents/sync/nodo/repository/historic/payment/HistoricRptRepository.java
@@ -1,0 +1,21 @@
+package it.gov.pagopa.bizevents.sync.nodo.repository.historic.payment;
+
+import it.gov.pagopa.bizevents.sync.nodo.entity.nodo.oldmodel.Rpt;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface HistoricRptRepository extends JpaRepository<Rpt, Long> {
+
+  @Query(
+      """
+      SELECT rpt
+      FROM Rpt rpt
+      WHERE rpt.identDominio = :domainId
+        AND rpt.iuv = :iuv
+        AND rpt.ccp = :ccp
+      """)
+  Optional<Rpt> readByUniqueIdentifier(
+      @Param("domainId") String domainId, @Param("iuv") String iuv, @Param("ccp") String ccp);
+}

--- a/src/main/java/it/gov/pagopa/bizevents/sync/nodo/repository/historic/payment/HistoricRptSoggettiRepository.java
+++ b/src/main/java/it/gov/pagopa/bizevents/sync/nodo/repository/historic/payment/HistoricRptSoggettiRepository.java
@@ -1,4 +1,4 @@
-package it.gov.pagopa.bizevents.sync.nodo.repository.payment;
+package it.gov.pagopa.bizevents.sync.nodo.repository.historic.payment;
 
 import it.gov.pagopa.bizevents.sync.nodo.entity.nodo.oldmodel.RptSoggetti;
 import it.gov.pagopa.bizevents.sync.nodo.entity.nodo.oldmodel.RptSoggettiId;
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface RptSoggettiRepository extends JpaRepository<RptSoggetti, RptSoggettiId> {
+public interface HistoricRptSoggettiRepository extends JpaRepository<RptSoggetti, RptSoggettiId> {
 
   @Query(
       """

--- a/src/main/java/it/gov/pagopa/bizevents/sync/nodo/repository/historic/payment/HistoricRptVersamentiRepository.java
+++ b/src/main/java/it/gov/pagopa/bizevents/sync/nodo/repository/historic/payment/HistoricRptVersamentiRepository.java
@@ -1,0 +1,19 @@
+package it.gov.pagopa.bizevents.sync.nodo.repository.historic.payment;
+
+import it.gov.pagopa.bizevents.sync.nodo.entity.nodo.oldmodel.RptVersamenti;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface HistoricRptVersamentiRepository extends JpaRepository<RptVersamenti, Long> {
+
+  @Query(
+      """
+      SELECT rptv
+      FROM RptVersamenti rptv
+      WHERE rptv.fkRpt = :rptId
+      ORDER BY rptv.progressivo ASC
+      """)
+  List<RptVersamenti> readByRptId(@Param("rptId") Long rptId);
+}

--- a/src/main/java/it/gov/pagopa/bizevents/sync/nodo/repository/historic/receipt/HistoricPositionReceiptRepository.java
+++ b/src/main/java/it/gov/pagopa/bizevents/sync/nodo/repository/historic/receipt/HistoricPositionReceiptRepository.java
@@ -1,4 +1,4 @@
-package it.gov.pagopa.bizevents.sync.nodo.repository.receipt;
+package it.gov.pagopa.bizevents.sync.nodo.repository.historic.receipt;
 
 import it.gov.pagopa.bizevents.sync.nodo.entity.nodo.newmodel.PositionReceipt;
 import it.gov.pagopa.bizevents.sync.nodo.model.bizevent.ReceiptEventInfo;
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-public interface PositionReceiptRepository extends JpaRepository<PositionReceipt, Long> {
+public interface HistoricPositionReceiptRepository extends JpaRepository<PositionReceipt, Long> {
 
   @Query(
       """
@@ -22,17 +22,12 @@ public interface PositionReceiptRepository extends JpaRepository<PositionReceipt
       FROM PositionReceipt pr
       WHERE pr.paymentDateTime >= :minDate
         AND pr.paymentDateTime < :maxDate
+        AND pr.paFiscalCode = :domainId
+        AND pr.noticeId = :noticeNumber
       """)
-  Set<ReceiptEventInfo> readReceiptsInTimeSlot(
-      @Param("minDate") LocalDateTime minDate, @Param("maxDate") LocalDateTime maxDate);
-
-  @Query(
-      """
-      SELECT COUNT(pr)
-      FROM PositionReceipt pr
-      WHERE pr.paymentDateTime >= :minDate
-        AND pr.paymentDateTime < :maxDate
-      """)
-  long countByTimeSlot(
-      @Param("minDate") LocalDateTime minDate, @Param("maxDate") LocalDateTime maxDate);
+  Set<ReceiptEventInfo> readReceiptsByDomainAndNoticeNumberInTimeSlot(
+      @Param("minDate") LocalDateTime minDate,
+      @Param("maxDate") LocalDateTime maxDate,
+      @Param("domainId") String domainId,
+      @Param("noticeNumber") String noticeNumber);
 }

--- a/src/main/java/it/gov/pagopa/bizevents/sync/nodo/repository/primary/payment/PaymentPositionRepository.java
+++ b/src/main/java/it/gov/pagopa/bizevents/sync/nodo/repository/primary/payment/PaymentPositionRepository.java
@@ -1,4 +1,4 @@
-package it.gov.pagopa.bizevents.sync.nodo.repository.payment;
+package it.gov.pagopa.bizevents.sync.nodo.repository.primary.payment;
 
 import it.gov.pagopa.bizevents.sync.nodo.entity.nodo.newmodel.PositionPayment;
 import java.time.LocalDateTime;

--- a/src/main/java/it/gov/pagopa/bizevents/sync/nodo/repository/primary/payment/PositionTransferRepository.java
+++ b/src/main/java/it/gov/pagopa/bizevents/sync/nodo/repository/primary/payment/PositionTransferRepository.java
@@ -1,4 +1,4 @@
-package it.gov.pagopa.bizevents.sync.nodo.repository.payment;
+package it.gov.pagopa.bizevents.sync.nodo.repository.primary.payment;
 
 import it.gov.pagopa.bizevents.sync.nodo.entity.nodo.newmodel.PositionTransfer;
 import java.time.LocalDateTime;

--- a/src/main/java/it/gov/pagopa/bizevents/sync/nodo/repository/primary/payment/RptRepository.java
+++ b/src/main/java/it/gov/pagopa/bizevents/sync/nodo/repository/primary/payment/RptRepository.java
@@ -1,4 +1,4 @@
-package it.gov.pagopa.bizevents.sync.nodo.repository.payment;
+package it.gov.pagopa.bizevents.sync.nodo.repository.primary.payment;
 
 import it.gov.pagopa.bizevents.sync.nodo.entity.nodo.oldmodel.Rpt;
 import java.util.Optional;

--- a/src/main/java/it/gov/pagopa/bizevents/sync/nodo/repository/primary/payment/RptSoggettiRepository.java
+++ b/src/main/java/it/gov/pagopa/bizevents/sync/nodo/repository/primary/payment/RptSoggettiRepository.java
@@ -1,0 +1,19 @@
+package it.gov.pagopa.bizevents.sync.nodo.repository.primary.payment;
+
+import it.gov.pagopa.bizevents.sync.nodo.entity.nodo.oldmodel.RptSoggetti;
+import it.gov.pagopa.bizevents.sync.nodo.entity.nodo.oldmodel.RptSoggettiId;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface RptSoggettiRepository extends JpaRepository<RptSoggetti, RptSoggettiId> {
+
+  @Query(
+      """
+      SELECT rs
+      FROM RptSoggetti rs
+      WHERE rs.id.rptId = :rptId
+      """)
+  List<RptSoggetti> readByRptId(@Param("rptId") Long rptId);
+}

--- a/src/main/java/it/gov/pagopa/bizevents/sync/nodo/repository/primary/payment/RptVersamentiRepository.java
+++ b/src/main/java/it/gov/pagopa/bizevents/sync/nodo/repository/primary/payment/RptVersamentiRepository.java
@@ -1,4 +1,4 @@
-package it.gov.pagopa.bizevents.sync.nodo.repository.payment;
+package it.gov.pagopa.bizevents.sync.nodo.repository.primary.payment;
 
 import it.gov.pagopa.bizevents.sync.nodo.entity.nodo.oldmodel.RptVersamenti;
 import java.util.List;

--- a/src/main/java/it/gov/pagopa/bizevents/sync/nodo/repository/primary/receipt/PositionReceiptRepository.java
+++ b/src/main/java/it/gov/pagopa/bizevents/sync/nodo/repository/primary/receipt/PositionReceiptRepository.java
@@ -1,0 +1,59 @@
+package it.gov.pagopa.bizevents.sync.nodo.repository.primary.receipt;
+
+import it.gov.pagopa.bizevents.sync.nodo.entity.nodo.newmodel.PositionReceipt;
+import it.gov.pagopa.bizevents.sync.nodo.model.bizevent.ReceiptEventInfo;
+import java.time.LocalDateTime;
+import java.util.Set;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface PositionReceiptRepository extends JpaRepository<PositionReceipt, Long> {
+
+  @Query(
+      """
+      SELECT new it.gov.pagopa.bizevents.sync.nodo.model.bizevent.ReceiptEventInfo(
+          pr.noticeId AS iuv,
+          pr.paymentToken AS paymentToken,
+          pr.paFiscalCode AS domainId,
+          pr.insertedTimestamp AS insertedTimestamp,
+          it.gov.pagopa.bizevents.sync.nodo.model.enumeration.PaymentModelVersion.NEW AS version
+      )
+      FROM PositionReceipt pr
+      WHERE pr.paymentDateTime >= :minDate
+        AND pr.paymentDateTime < :maxDate
+      """)
+  Set<ReceiptEventInfo> readReceiptsInTimeSlot(
+      @Param("minDate") LocalDateTime minDate, @Param("maxDate") LocalDateTime maxDate);
+
+  @Query(
+      """
+      SELECT new it.gov.pagopa.bizevents.sync.nodo.model.bizevent.ReceiptEventInfo(
+          pr.noticeId AS iuv,
+          pr.paymentToken AS paymentToken,
+          pr.paFiscalCode AS domainId,
+          pr.insertedTimestamp AS insertedTimestamp,
+          it.gov.pagopa.bizevents.sync.nodo.model.enumeration.PaymentModelVersion.NEW AS version
+      )
+      FROM PositionReceipt pr
+      WHERE pr.paymentDateTime >= :minDate
+        AND pr.paymentDateTime < :maxDate
+        AND pr.paFiscalCode = :domainId
+        AND pr.noticeId = :noticeNumber
+      """)
+  Set<ReceiptEventInfo> readReceiptsByDomainAndNoticeNumberInTimeSlot(
+      @Param("minDate") LocalDateTime minDate,
+      @Param("maxDate") LocalDateTime maxDate,
+      @Param("domainId") String domainId,
+      @Param("noticeNumber") String noticeNumber);
+
+  @Query(
+      """
+      SELECT COUNT(pr)
+      FROM PositionReceipt pr
+      WHERE pr.paymentDateTime >= :minDate
+        AND pr.paymentDateTime < :maxDate
+      """)
+  long countByTimeSlot(
+      @Param("minDate") LocalDateTime minDate, @Param("maxDate") LocalDateTime maxDate);
+}

--- a/src/main/java/it/gov/pagopa/bizevents/sync/nodo/repository/primary/receipt/RtRepository.java
+++ b/src/main/java/it/gov/pagopa/bizevents/sync/nodo/repository/primary/receipt/RtRepository.java
@@ -1,0 +1,101 @@
+package it.gov.pagopa.bizevents.sync.nodo.repository.primary.receipt;
+
+import it.gov.pagopa.bizevents.sync.nodo.entity.nodo.oldmodel.Rt;
+import it.gov.pagopa.bizevents.sync.nodo.model.bizevent.ReceiptEventInfo;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.Set;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface RtRepository extends JpaRepository<Rt, Long> {
+
+  @Query(
+      """
+      SELECT DISTINCT new it.gov.pagopa.bizevents.sync.nodo.model.bizevent.ReceiptEventInfo(
+          rt.iuv AS iuv,
+          rt.ccp AS paymentToken,
+          rt.identDominio AS domainId,
+          rt.insertedTimestamp AS insertedTimestamp,
+          it.gov.pagopa.bizevents.sync.nodo.model.enumeration.PaymentModelVersion.OLD AS version
+      )
+      FROM Rt rt
+      JOIN Rpt rpt
+        ON rpt.identDominio = rt.identDominio AND rpt.iuv = rt.iuv AND rpt.ccp = rt.ccp
+      WHERE rt.esito = 'ESEGUITO'
+        AND rt.dataRicevuta >= :minDate
+        AND rt.dataRicevuta < :maxDate
+        AND (rpt.flagSeconda = 'N' OR rpt.flagSeconda IS NULL OR rpt.flagSeconda = 'Y')
+        AND rt.generataDa = 'PSP'
+      """)
+  Set<ReceiptEventInfo> readReceiptsInTimeSlot(
+      @Param("minDate") LocalDateTime minDate, @Param("maxDate") LocalDateTime maxDate);
+
+  @Query(
+      """
+      SELECT DISTINCT new it.gov.pagopa.bizevents.sync.nodo.model.bizevent.ReceiptEventInfo(
+          rt.iuv AS iuv,
+          rt.ccp AS paymentToken,
+          rt.identDominio AS domainId,
+          rt.insertedTimestamp AS insertedTimestamp,
+          it.gov.pagopa.bizevents.sync.nodo.model.enumeration.PaymentModelVersion.OLD AS version
+      )
+      FROM Rt rt
+      JOIN Rpt rpt
+        ON rpt.identDominio = rt.identDominio AND rpt.iuv = rt.iuv AND rpt.ccp = rt.ccp
+      WHERE rpt.iuv = :noticeNumber
+        AND rpt.identDominio = :domainId
+        AND rt.esito = 'ESEGUITO'
+        AND rt.dataRicevuta >= :minDate
+        AND rt.dataRicevuta < :maxDate
+        AND (rpt.flagSeconda = 'N' OR rpt.flagSeconda IS NULL OR rpt.flagSeconda = 'Y')
+        AND rt.generataDa = 'PSP'
+      """)
+  Set<ReceiptEventInfo> readReceiptsByDomainAndNoticeNumbeInTimeSlot(
+      @Param("minDate") LocalDateTime minDate,
+      @Param("maxDate") LocalDateTime maxDate,
+      @Param("domainId") String domainId,
+      @Param("noticeNumber") String noticeNumber);
+
+  @Query(
+      """
+      SELECT rt
+      FROM Rt rt
+      WHERE rt.identDominio = :domainId
+        AND rt.iuv = :iuv
+        AND rt.ccp = :ccp
+      """)
+  Optional<Rt> readByUniqueIdentifier(
+      @Param("domainId") String domainId, @Param("iuv") String iuv, @Param("ccp") String ccp);
+
+  @Query(
+      """
+      SELECT COUNT(rt)
+      FROM Rt rt
+      JOIN Rpt rpt
+        ON rpt.identDominio = rt.identDominio AND rpt.iuv = rt.iuv AND rpt.ccp = rt.ccp
+      WHERE rt.esito = 'ESEGUITO'
+        AND rt.dataRicevuta >= :minDate
+        AND rt.dataRicevuta < :maxDate
+        AND (rpt.flagSeconda = 'N' OR rpt.flagSeconda IS NULL)
+        AND rt.generataDa = 'PSP'
+      """)
+  long countFirstRPTsByTimeSlot(
+      @Param("minDate") LocalDateTime minDate, @Param("maxDate") LocalDateTime maxDate);
+
+  @Query(
+      """
+      SELECT COUNT(rt)
+      FROM Rt rt
+      JOIN Rpt rpt
+        ON rpt.identDominio = rt.identDominio AND rpt.iuv = rt.iuv AND rpt.ccp = rt.ccp
+      WHERE rt.esito = 'ESEGUITO'
+        AND rt.dataRicevuta >= :minDate
+        AND rt.dataRicevuta < :maxDate
+        AND rpt.flagSeconda = 'Y'
+        AND rt.generataDa = 'PSP'
+      """)
+  long countRetriedRPTsByTimeSlot(
+      @Param("minDate") LocalDateTime minDate, @Param("maxDate") LocalDateTime maxDate);
+}

--- a/src/main/java/it/gov/pagopa/bizevents/sync/nodo/service/PaymentPositionReaderService.java
+++ b/src/main/java/it/gov/pagopa/bizevents/sync/nodo/service/PaymentPositionReaderService.java
@@ -10,12 +10,10 @@ import it.gov.pagopa.bizevents.sync.nodo.entity.nodo.oldmodel.Rt;
 import it.gov.pagopa.bizevents.sync.nodo.exception.BizEventSyncException;
 import it.gov.pagopa.bizevents.sync.nodo.model.bizevent.ReceiptEventInfo;
 import it.gov.pagopa.bizevents.sync.nodo.model.mapper.BizEventMapper;
-import it.gov.pagopa.bizevents.sync.nodo.repository.payment.PaymentPositionRepository;
-import it.gov.pagopa.bizevents.sync.nodo.repository.payment.PositionTransferRepository;
-import it.gov.pagopa.bizevents.sync.nodo.repository.payment.RptRepository;
-import it.gov.pagopa.bizevents.sync.nodo.repository.payment.RptSoggettiRepository;
-import it.gov.pagopa.bizevents.sync.nodo.repository.payment.RptVersamentiRepository;
-import it.gov.pagopa.bizevents.sync.nodo.repository.receipt.RtRepository;
+import it.gov.pagopa.bizevents.sync.nodo.repository.historic.payment.*;
+import it.gov.pagopa.bizevents.sync.nodo.repository.historic.receipt.HistoricRtRepository;
+import it.gov.pagopa.bizevents.sync.nodo.repository.primary.payment.*;
+import it.gov.pagopa.bizevents.sync.nodo.repository.primary.receipt.RtRepository;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
@@ -40,6 +38,18 @@ public class PaymentPositionReaderService {
 
   private final RptVersamentiRepository rptVersamentiRepository;
 
+  private final HistoricPaymentPositionRepository historicPaymentPositionRepository;
+
+  private final HistoricPositionTransferRepository historicPositionTransferRepository;
+
+  private final HistoricRtRepository historicRtRepository;
+
+  private final HistoricRptRepository historicRptRepository;
+
+  private final HistoricRptSoggettiRepository historicRptSoggettiRepository;
+
+  private final HistoricRptVersamentiRepository historicRptVersamentiRepository;
+
   private final ConfigCacheService configCacheService;
 
   public PaymentPositionReaderService(
@@ -49,6 +59,12 @@ public class PaymentPositionReaderService {
       RptRepository rptRepository,
       RptSoggettiRepository rptSoggettiRepository,
       RptVersamentiRepository rptVersamentiRepository,
+      HistoricPaymentPositionRepository historicPaymentPositionRepository,
+      HistoricPositionTransferRepository historicPositionTransferRepository,
+      HistoricRtRepository historicRtRepository,
+      HistoricRptRepository historicRptRepository,
+      HistoricRptSoggettiRepository historicRptSoggettiRepository,
+      HistoricRptVersamentiRepository historicRptVersamentiRepository,
       ConfigCacheService configCacheService) {
 
     this.paymentPositionRepository = paymentPositionRepository;
@@ -57,6 +73,12 @@ public class PaymentPositionReaderService {
     this.rptRepository = rptRepository;
     this.rptSoggettiRepository = rptSoggettiRepository;
     this.rptVersamentiRepository = rptVersamentiRepository;
+    this.historicPaymentPositionRepository = historicPaymentPositionRepository;
+    this.historicPositionTransferRepository = historicPositionTransferRepository;
+    this.historicRtRepository = historicRtRepository;
+    this.historicRptRepository = historicRptRepository;
+    this.historicRptSoggettiRepository = historicRptSoggettiRepository;
+    this.historicRptVersamentiRepository = historicRptVersamentiRepository;
     this.configCacheService = configCacheService;
   }
 
@@ -65,8 +87,8 @@ public class PaymentPositionReaderService {
     BizEvent bizEvent;
     LocalDateTime insertedTimestamp =
         receiptEvent.getInsertedTimestamp().truncatedTo(ChronoUnit.DAYS);
-    LocalDateTime minDate = LocalDateTime.from(insertedTimestamp);
-    LocalDateTime maxDate = LocalDateTime.from(insertedTimestamp.plusDays(1));
+    LocalDateTime minDate = insertedTimestamp;
+    LocalDateTime maxDate = insertedTimestamp.plusDays(1);
     String paymentToken = receiptEvent.getPaymentToken();
 
     try {
@@ -147,6 +169,110 @@ public class PaymentPositionReaderService {
       Long rptId = rpt.getId();
       List<RptSoggetti> rptSubjects = this.rptSoggettiRepository.readByRptId(rptId);
       List<RptVersamenti> rptTransfers = this.rptVersamentiRepository.readByRptId(rptId);
+
+      bizEvent =
+          BizEventMapper.fromOldModel(
+              rpt, rt, rptSubjects, rptTransfers, configCacheService.getConfigData());
+
+    } catch (DataAccessException e) {
+      String msg =
+          String.format(
+              "An error occurred during read operation on tables for domainId=[%s] iuv=[%s]"
+                  + " ccp=[%s]",
+              domainId, iuv, ccp);
+      throw new BizEventSyncException(msg, e);
+    }
+    return bizEvent;
+  }
+
+  public BizEvent readNewModelPaymentPositionFromHistoric(ReceiptEventInfo receiptEvent) {
+
+    BizEvent bizEvent;
+    LocalDateTime insertedTimestamp =
+        receiptEvent.getInsertedTimestamp().truncatedTo(ChronoUnit.DAYS);
+    LocalDateTime minDate = insertedTimestamp;
+    LocalDateTime maxDate = insertedTimestamp.plusDays(1);
+    String paymentToken = receiptEvent.getPaymentToken();
+
+    try {
+      Optional<PositionPayment> positionPaymentOpt =
+          this.historicPaymentPositionRepository.readByPaymentTokenInTimeSlot(
+              minDate, maxDate, paymentToken);
+      if (positionPaymentOpt.isEmpty()) {
+        String msg =
+            String.format(
+                "No valid record found in POSITION_PAYMENT table for paymentToken=[%s] in"
+                    + " range=[%s-%s]",
+                paymentToken, minDate, maxDate);
+        throw new BizEventSyncException(msg);
+      }
+
+      PositionPayment positionPayment = positionPaymentOpt.get();
+      Long totalNotices = 1L;
+      if ("v2".equalsIgnoreCase(positionPayment.getCloseVersion())) {
+        totalNotices =
+            this.historicPaymentPositionRepository.countPositionPaymentsByTransactionId(
+                positionPayment.getTransactionId());
+      }
+
+      List<PositionTransfer> positionTransfers =
+          this.historicPositionTransferRepository.readByPositionPayment(
+              positionPayment.getId(), minDate);
+      if (positionTransfers.isEmpty()) {
+        String msg =
+            String.format(
+                "No valid record found in POSITION_TRANSFER table for FK_POSITION_PAYMENT=[%s] with"
+                    + " inserted timestamp > [%s]",
+                positionPayment.getId(), minDate);
+        throw new BizEventSyncException(msg);
+      }
+
+      bizEvent =
+          BizEventMapper.fromNewModel(
+              positionPayment, positionTransfers, totalNotices, configCacheService.getConfigData());
+
+    } catch (DataAccessException e) {
+      String msg =
+          String.format(
+              "An error occurred during read operation on tables for paymentToken=[%s]",
+              paymentToken);
+      throw new BizEventSyncException(msg, e);
+    }
+
+    return bizEvent;
+  }
+
+  public BizEvent readOldModelPaymentPositionFromHistoric(ReceiptEventInfo receiptEvent) {
+
+    BizEvent bizEvent;
+    String domainId = receiptEvent.getDomainId();
+    String iuv = receiptEvent.getIuv();
+    String ccp = receiptEvent.getPaymentToken();
+
+    try {
+      Optional<Rpt> rptOpt = this.historicRptRepository.readByUniqueIdentifier(domainId, iuv, ccp);
+      if (rptOpt.isEmpty()) {
+        String msg =
+            String.format(
+                "No valid record found in RPT table for domainId=[%s] iuv=[%s] ccp=[%s]",
+                domainId, iuv, ccp);
+        throw new BizEventSyncException(msg);
+      }
+      Rpt rpt = rptOpt.get();
+
+      Optional<Rt> rtOpt = this.historicRtRepository.readByUniqueIdentifier(domainId, iuv, ccp);
+      if (rtOpt.isEmpty()) {
+        String msg =
+            String.format(
+                "No valid record found in RT table for domainId=[%s] iuv=[%s] ccp=[%s]",
+                domainId, iuv, ccp);
+        throw new BizEventSyncException(msg);
+      }
+      Rt rt = rtOpt.get();
+
+      Long rptId = rpt.getId();
+      List<RptSoggetti> rptSubjects = this.historicRptSoggettiRepository.readByRptId(rptId);
+      List<RptVersamenti> rptTransfers = this.historicRptVersamentiRepository.readByRptId(rptId);
 
       bizEvent =
           BizEventMapper.fromOldModel(

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -35,7 +35,7 @@ spring.jpa.properties.hibernate.default_schema=${DATABASE_SCHEMA}
 spring.jpa.open-in-view=false
 # Batches (cron expression refers to UTC timezones)
 cron.job.schedule.enabled=${CRONJOB_SCHEDULE_ENABLED:true}
-# Nodo's oracle db config
+# Nodo's Primary ONLINE db config
 spring.datasource.url=${SPRING_DATASOURCE_URL}
 spring.datasource.username=${SPRING_DATASOURCE_USERNAME}
 spring.datasource.password=${SPRING_DATASOURCE_PASSWORD}
@@ -44,6 +44,16 @@ spring.datasource.health-check.query=${SPRING_DATASOURCE_HEALTHCHECK_QUERY:SELEC
 spring.datasource.hikari.maxLifetime=${SPRING_DATASOURCE_HIKARI_MAXLIFETIME:30000}
 spring.datasource.hikari.keepaliveTime=${SPRING_DATASOURCE_HIKARI_KEEPALIVETIME:20000}
 spring.datasource.hikari.connectionTimeout=${SPRING_DATASOURCE_HIKARI_CONNECTIONTIMEOUT:15000}
+# Nodo's STORICO ONLINE db config
+historic.historicization-after.days=90
+historic.datasource.url=${HISTORIC_DATASOURCE_URL}
+historic.datasource.username=${HISTORIC_DATASOURCE_USERNAME}
+historic.datasource.password=${HISTORIC_DATASOURCE_PASSWORD}
+historic.datasource.driver-class-name=${HISTORIC_DATASOURCE_DRIVER}
+historic.datasource.health-check.query=${HISTORIC_DATASOURCE_HEALTHCHECK_QUERY:SELECT 1 FROM DUAL}
+historic.datasource.hikari.maxLifetime=${HISTORIC_DATASOURCE_HIKARI_MAXLIFETIME:30000}
+historic.datasource.hikari.keepaliveTime=${HISTORIC_DATASOURCE_HIKARI_KEEPALIVETIME:20000}
+historic.datasource.hikari.connectionTimeout=${HISTORIC_DATASOURCE_HIKARI_CONNECTIONTIMEOUT:15000}
 # Cosmos DB config
 azure.cosmos.uri=${COSMOS_DB_URI}
 azure.cosmos.key=${COSMOS_DB_PRIMARY_KEY}


### PR DESCRIPTION
This PR contains a **proposal** for the `COSO (Catching Out-of-sync Operation)` application.  
The proposal aims to define a new API to reconcile individual BizEvents. Currently, this cannot be done because the process (manual or automatic) runs on a specific time-slot, operating on multiple elements in batch-mode. With this new API, it is possible to directly reconcile a single receipt and convert it into a BizEvent, with the precondition that no valid event has previously been generated by the automatic processes of the pagoPA platform.   
An interesting feature that this proposal also includes is the ability to search into the **historical** database, permitting the reconciliation of payments that, in any case, cannot be generated by current automatic processes or manual synchronisation. This functionality is defined _**only**_ for the synchronisation of single events, in order to avoid large, infinite queries not indexed on the historical DB.

#### List of Changes
 - Adding double persistence, permitting search in current DB instance and in historic DB instance
 - Including new API that permits to reconcile single receipts in BizEvents 

#### Motivation and Context
These changes are a proposal that helps to recover single error on unconverted receipts.

#### How Has This Been Tested?
 - Tested in local pointing to PROD databases

#### Screenshots (if appropriate):

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
